### PR TITLE
Allow node to node communication

### DIFF
--- a/examples/from-private-vpc/main.tf
+++ b/examples/from-private-vpc/main.tf
@@ -43,6 +43,14 @@ module "eks" {
       cidr_blocks      = ["0.0.0.0/0"]
       ipv6_cidr_blocks = ["::/0"]
     }
+    ingress_self_all_to_all = {
+      description = "Node to node all traffic"
+      protocol    = "-1"
+      from_port   = 0
+      to_port     = 0
+      type        = "ingress"
+      self        = true
+    }
   }
 
 }

--- a/examples/from-scratch/main.tf
+++ b/examples/from-scratch/main.tf
@@ -87,6 +87,14 @@ module "eks" {
       cidr_blocks      = ["0.0.0.0/0"]
       ipv6_cidr_blocks = ["::/0"]
     }
+    ingress_self_all_to_all = {
+      description = "Node to node all traffic"
+      protocol    = "-1"
+      from_port   = 0
+      to_port     = 0
+      type        = "ingress"
+      self        = true
+    }
   }
 
 }

--- a/examples/import-eks-cluster/eks-cluster/main.tf
+++ b/examples/import-eks-cluster/eks-cluster/main.tf
@@ -87,6 +87,14 @@ module "eks" {
       cidr_blocks      = ["0.0.0.0/0"]
       ipv6_cidr_blocks = ["::/0"]
     }
+    ingress_self_all_to_all = {
+      description = "Node to node all traffic"
+      protocol    = "-1"
+      from_port   = 0
+      to_port     = 0
+      type        = "ingress"
+      self        = true
+    }
   }
 
 }


### PR DESCRIPTION
Otherwise:
* Executors can't report back to their driver
* The notebook-service can't mount the notebook-storage-server volume