### PR TITLE
Add support for EKS Blueprints in examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 terraform.tfstate
 terraform.tfstate.backup
 *.tfvars
+!examples/from-scratch-eks-blueprint/secrets-example.tfvars
+!examples/from-vpc-eks-blueprint/secrets-example.tfvars
 
 kubeconfig*
 

--- a/examples/from-scratch-eks-blueprint/main.tf
+++ b/examples/from-scratch-eks-blueprint/main.tf
@@ -1,0 +1,238 @@
+#################################
+### Locals ######################
+#################################
+
+locals {
+  public_1  = cidrsubnet(var.vpc_cidr, 2, 0)
+  public_2  = cidrsubnet(var.vpc_cidr, 2, 1)
+  private_1 = cidrsubnet(var.vpc_cidr, 2, 2)
+  private_2 = cidrsubnet(var.vpc_cidr, 2, 3)
+  tags = {
+    creator   = var.creator_email,
+    createdby = "terraform",
+    protected = "weekend"
+  }
+}
+
+#################################
+### Create VPC ##################
+#################################
+
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 2.70"
+
+  create_vpc           = true
+  name                 = var.vpc_name
+  cidr                 = var.vpc_cidr
+  azs                  = var.azs
+  private_subnets      = [local.private_1, local.private_2]
+  public_subnets       = [local.public_1, local.public_2]
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  enable_s3_endpoint   = true
+
+  tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared",
+  }
+
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                    = "1"
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"           = "1"
+  }
+}
+
+#############################################
+### Create EKS Cluster ######################
+#############################################
+
+data "aws_eks_cluster_auth" "this" {
+  name = module.eks_blueprints.eks_cluster_id
+}
+
+provider "kubernetes" {
+  host                   = module.eks_blueprints.eks_cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
+provider "kubectl" {
+  apply_retry_count      = 10
+  host                   = module.eks_blueprints.eks_cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
+  load_config_file       = false
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = module.eks_blueprints.eks_cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
+    token                  = data.aws_eks_cluster_auth.this.token
+  }
+}
+
+module "eks_blueprints" {
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints"
+
+  # EKS CLUSTER
+  cluster_name       = var.cluster_name
+  cluster_version    = var.cluster_version
+  vpc_id             = module.vpc.vpc_id
+  private_subnet_ids = module.vpc.private_subnets
+  public_subnet_ids  = module.vpc.public_subnets
+  map_roles = [
+    {
+      rolearn  = aws_iam_role.nodes.arn
+      username = "system:node:{{EC2PrivateDNSName}}"
+      groups   = ["system:bootstrappers", "system:nodes"]
+    }
+  ]
+
+  tags = local.tags
+}
+
+module "eks_blueprints_kubernetes_addons" {
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons"
+
+  eks_cluster_id = module.eks_blueprints.eks_cluster_id
+
+  #K8s Add-ons
+  enable_metrics_server = true
+
+  depends_on = [
+    module.ocean-aws-k8s
+  ]
+}
+
+output "configure_kubectl" {
+  description = "Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig"
+  value       = module.eks_blueprints.configure_kubectl
+}
+
+#############################################
+### Create EKS Node IAM Role and Profile ####
+#############################################
+
+resource "aws_iam_role" "nodes" {
+  name = "${var.cluster_name}-nodeRole-group"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "amazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.nodes.name
+}
+
+resource "aws_iam_role_policy_attachment" "amazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.nodes.name
+}
+
+resource "aws_iam_role_policy_attachment" "amazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.nodes.name
+}
+
+resource "aws_iam_instance_profile" "profile" {
+  name = "${var.cluster_name}-nodeProfile-group"
+  role = aws_iam_role.nodes.name
+}
+
+#############################################
+### Create Ocean Cluster ####################
+#############################################
+
+resource "null_resource" "patience" {
+  depends_on = [module.eks_blueprints]
+
+  provisioner "local-exec" {
+    command = "sleep 10"
+  }
+}
+
+module "ocean-aws-k8s" {
+  source = "spotinst/ocean-aws-k8s/spotinst"
+
+  # Configuration
+  cluster_name                = var.cluster_name
+  region                      = var.aws_region
+  subnet_ids                  = concat(module.vpc.public_subnets, module.vpc.private_subnets)
+  worker_instance_profile_arn = aws_iam_instance_profile.profile.arn
+  security_groups             = [module.eks_blueprints.cluster_primary_security_group_id]
+  min_size                    = 0
+
+  tags = local.tags
+
+  shutdown_hours = {
+    is_enabled = true
+    time_windows = [ # Must be in GMT
+      "Fri:23:30-Mon:13:30", # Weekends
+      "Mon:23:30-Tue:13:30", # Weekday evenings
+      "Tue:23:30-Wed:13:30",
+      "Wed:23:30-Thu:13:30",
+      "Thu:23:30-Fri:13:30",
+    ]
+  }
+
+  depends_on = [
+    null_resource.patience
+  ]
+}
+
+#############################################
+### Install Ocean Controller ################
+#############################################
+
+provider "spotinst" {
+  token   = var.spotinst_token
+  account = var.spotinst_account
+}
+
+module "ocean-controller" {
+  source = "spotinst/ocean-controller/spotinst"
+
+  # Credentials.
+  spotinst_token   = var.spotinst_token
+  spotinst_account = var.spotinst_account
+
+  # Configuration.
+  cluster_identifier = var.cluster_name
+
+  depends_on = [
+    module.ocean-aws-k8s
+  ]
+}
+
+module "ocean-spark" {
+  source = "spotinst/ocean-spark/spotinst"
+  version = "1.1.1"
+
+  ocean_cluster_id = module.ocean-aws-k8s.ocean_id
+
+  depends_on = [
+    module.ocean-aws-k8s
+  ]
+}

--- a/examples/from-scratch-eks-blueprint/main.tf
+++ b/examples/from-scratch-eks-blueprint/main.tf
@@ -188,7 +188,7 @@ module "ocean-aws-k8s" {
 
   shutdown_hours = {
     is_enabled = true
-    time_windows = [ # Must be in GMT
+    time_windows = [         # Must be in GMT
       "Fri:23:30-Mon:13:30", # Weekends
       "Mon:23:30-Tue:13:30", # Weekday evenings
       "Tue:23:30-Wed:13:30",
@@ -227,7 +227,7 @@ module "ocean-controller" {
 }
 
 module "ocean-spark" {
-  source = "spotinst/ocean-spark/spotinst"
+  source  = "spotinst/ocean-spark/spotinst"
   version = "1.1.1"
 
   ocean_cluster_id = module.ocean-aws-k8s.ocean_id

--- a/examples/from-scratch-eks-blueprint/providers.tf
+++ b/examples/from-scratch-eks-blueprint/providers.tf
@@ -1,0 +1,17 @@
+terraform {
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+    }
+    spotinst = {
+      source = "spotinst/spotinst"
+    }
+  }
+}

--- a/examples/from-scratch-eks-blueprint/providers.tf
+++ b/examples/from-scratch-eks-blueprint/providers.tf
@@ -2,13 +2,13 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
+      source = "hashicorp/aws"
     }
     kubernetes = {
-      source  = "hashicorp/kubernetes"
+      source = "hashicorp/kubernetes"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
+      source = "gavinbunney/kubectl"
     }
     spotinst = {
       source = "spotinst/spotinst"

--- a/examples/from-scratch-eks-blueprint/secrets-example.tfvars
+++ b/examples/from-scratch-eks-blueprint/secrets-example.tfvars
@@ -1,0 +1,10 @@
+spotinst_token   = "0000000000000000000000000000000000000000000000000000000000000000"
+spotinst_account = "act-00000000"
+cluster_name     = "example-cluster-name"
+cluster_version  = "1.24"
+aws_region       = "us-west-2"
+aws_profile      = "default"
+creator_email    = "example@example.com"
+vpc_name         = "example-vpc-name"
+vpc_cidr         = "10.0.0.0/16"
+azs              = ["us-west-2c", "us-west-2d"]

--- a/examples/from-scratch-eks-blueprint/variables.tf
+++ b/examples/from-scratch-eks-blueprint/variables.tf
@@ -30,12 +30,12 @@ variable "aws_profile" {
 
 variable "vpc_name" {
   description = "Desired VPC Name"
-  type = string
+  type        = string
 }
 
 variable "vpc_cidr" {
   description = "Desired VPC CIDR"
-  type = string
+  type        = string
 }
 
 variable "azs" {

--- a/examples/from-scratch-eks-blueprint/variables.tf
+++ b/examples/from-scratch-eks-blueprint/variables.tf
@@ -1,0 +1,49 @@
+variable "spotinst_token" {
+  description = "Spot token"
+  type        = string
+}
+
+variable "spotinst_account" {
+  description = "Spot account id"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "EKS cluster and Ocean cluster name"
+  type        = string
+}
+
+variable "cluster_version" {
+  description = "Kubernetes version"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "aws_profile" {
+  description = "AWS profile"
+  type        = string
+}
+
+variable "vpc_name" {
+  description = "Desired VPC Name"
+  type = string
+}
+
+variable "vpc_cidr" {
+  description = "Desired VPC CIDR"
+  type = string
+}
+
+variable "azs" {
+  description = "List of availability zones"
+  type        = list(string)
+}
+
+variable "creator_email" {
+  description = "Creator's email"
+  type        = string
+}

--- a/examples/from-vpc-eks-blueprint/main.tf
+++ b/examples/from-vpc-eks-blueprint/main.tf
@@ -3,10 +3,9 @@
 #################################
 
 locals {
-    creator   = var.creator_email,
-    createdby = "terraform",
+    creator   = var.creator_email
+    createdby = "terraform"
     protected = "weekend"
-  }
 }
 
 provider "aws" {

--- a/examples/from-vpc-eks-blueprint/main.tf
+++ b/examples/from-vpc-eks-blueprint/main.tf
@@ -3,9 +3,9 @@
 #################################
 
 locals {
-    creator   = var.creator_email
-    createdby = "terraform"
-    protected = "weekend"
+  creator   = var.creator_email
+  createdby = "terraform"
+  protected = "weekend"
 }
 
 provider "aws" {
@@ -147,7 +147,7 @@ module "ocean-aws-k8s" {
 
   shutdown_hours = {
     is_enabled = true
-    time_windows = [ # Must be in GMT
+    time_windows = [         # Must be in GMT
       "Fri:23:30-Mon:13:30", # Weekends
       "Mon:23:30-Tue:13:30", # Weekday evenings
       "Tue:23:30-Wed:13:30",
@@ -186,7 +186,7 @@ module "ocean-controller" {
 }
 
 module "ocean-spark" {
-  source = "spotinst/ocean-spark/spotinst"
+  source  = "spotinst/ocean-spark/spotinst"
   version = "1.1.1"
 
   ocean_cluster_id = module.ocean-aws-k8s.ocean_id

--- a/examples/from-vpc-eks-blueprint/main.tf
+++ b/examples/from-vpc-eks-blueprint/main.tf
@@ -1,0 +1,198 @@
+#################################
+### Locals ######################
+#################################
+
+locals {
+    creator   = var.creator_email,
+    createdby = "terraform",
+    protected = "weekend"
+  }
+}
+
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+}
+
+#############################################
+### Create EKS Cluster ######################
+#############################################
+
+data "aws_eks_cluster_auth" "this" {
+  name = module.eks_blueprints.eks_cluster_id
+}
+
+provider "kubernetes" {
+  host                   = module.eks_blueprints.eks_cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
+provider "kubectl" {
+  apply_retry_count      = 10
+  host                   = module.eks_blueprints.eks_cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
+  load_config_file       = false
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = module.eks_blueprints.eks_cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
+    token                  = data.aws_eks_cluster_auth.this.token
+  }
+}
+
+module "eks_blueprints" {
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints"
+
+  # EKS CLUSTER
+  cluster_name       = var.cluster_name
+  cluster_version    = var.cluster_version
+  vpc_id             = var.vpc_id
+  private_subnet_ids = var.private_subnet_ids
+  public_subnet_ids  = var.public_subnet_ids
+  map_roles = [
+    {
+      rolearn  = aws_iam_role.nodes.arn
+      username = "system:node:{{EC2PrivateDNSName}}"
+      groups   = ["system:bootstrappers", "system:nodes"]
+    }
+  ]
+
+  tags = local.tags
+}
+
+module "eks_blueprints_kubernetes_addons" {
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons"
+
+  eks_cluster_id = module.eks_blueprints.eks_cluster_id
+
+  #K8s Add-ons
+  enable_metrics_server = true
+
+  depends_on = [
+    module.ocean-aws-k8s
+  ]
+}
+
+output "configure_kubectl" {
+  description = "Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig"
+  value       = module.eks_blueprints.configure_kubectl
+}
+
+#############################################
+### Create EKS Node IAM Role and Profile ####
+#############################################
+
+resource "aws_iam_role" "nodes" {
+  name = "${var.cluster_name}-nodeRole-group"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "amazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.nodes.name
+}
+
+resource "aws_iam_role_policy_attachment" "amazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.nodes.name
+}
+
+resource "aws_iam_role_policy_attachment" "amazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.nodes.name
+}
+
+resource "aws_iam_instance_profile" "profile" {
+  name = "${var.cluster_name}-nodeProfile-group"
+  role = aws_iam_role.nodes.name
+}
+
+#############################################
+### Create Ocean Cluster ####################
+#############################################
+
+resource "null_resource" "patience" {
+  depends_on = [module.eks_blueprints]
+
+  provisioner "local-exec" {
+    command = "sleep 10"
+  }
+}
+
+module "ocean-aws-k8s" {
+  source = "spotinst/ocean-aws-k8s/spotinst"
+
+  # Configuration
+  cluster_name                = var.cluster_name
+  region                      = var.aws_region
+  subnet_ids                  = concat(var.public_subnet_ids, var.private_subnet_ids)
+  worker_instance_profile_arn = aws_iam_instance_profile.profile.arn
+  security_groups             = [module.eks_blueprints.cluster_primary_security_group_id]
+  min_size                    = 0
+
+  tags = local.tags
+
+  shutdown_hours = {
+    is_enabled = true
+    time_windows = [ # Must be in GMT
+      "Fri:23:30-Mon:13:30", # Weekends
+      "Mon:23:30-Tue:13:30", # Weekday evenings
+      "Tue:23:30-Wed:13:30",
+      "Wed:23:30-Thu:13:30",
+      "Thu:23:30-Fri:13:30",
+    ]
+  }
+
+  depends_on = [
+    null_resource.patience
+  ]
+}
+
+#############################################
+### Install Ocean Controller ################
+#############################################
+
+provider "spotinst" {
+  token   = var.spotinst_token
+  account = var.spotinst_account
+}
+
+module "ocean-controller" {
+  source = "spotinst/ocean-controller/spotinst"
+
+  # Credentials.
+  spotinst_token   = var.spotinst_token
+  spotinst_account = var.spotinst_account
+
+  # Configuration.
+  cluster_identifier = var.cluster_name
+
+  depends_on = [
+    module.ocean-aws-k8s
+  ]
+}
+
+module "ocean-spark" {
+  source = "spotinst/ocean-spark/spotinst"
+  version = "1.1.1"
+
+  ocean_cluster_id = module.ocean-aws-k8s.ocean_id
+
+  depends_on = [
+    module.ocean-aws-k8s
+  ]
+}

--- a/examples/from-vpc-eks-blueprint/providers.tf
+++ b/examples/from-vpc-eks-blueprint/providers.tf
@@ -1,0 +1,17 @@
+terraform {
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+    }
+    spotinst = {
+      source = "spotinst/spotinst"
+    }
+  }
+}

--- a/examples/from-vpc-eks-blueprint/providers.tf
+++ b/examples/from-vpc-eks-blueprint/providers.tf
@@ -2,13 +2,13 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
+      source = "hashicorp/aws"
     }
     kubernetes = {
-      source  = "hashicorp/kubernetes"
+      source = "hashicorp/kubernetes"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
+      source = "gavinbunney/kubectl"
     }
     spotinst = {
       source = "spotinst/spotinst"

--- a/examples/from-vpc-eks-blueprint/secrets-example.tfvars
+++ b/examples/from-vpc-eks-blueprint/secrets-example.tfvars
@@ -4,7 +4,6 @@ cluster_name     = "example-cluster-name"
 cluster_version  = "1.24"
 aws_region       = "us-west-2"
 aws_profile      = "default"
-creator_email    = "example@example.com"
 vpc_id           = "vpc-00000000000000000"
 private_subnets  = ["subnet-00000000000000000", "subnet-00000000000000000", "subnet-00000000000000000"]
 public_subnets   = ["subnet-00000000000000000", "subnet-00000000000000000", "subnet-00000000000000000"]

--- a/examples/from-vpc-eks-blueprint/secrets-example.tfvars
+++ b/examples/from-vpc-eks-blueprint/secrets-example.tfvars
@@ -1,0 +1,11 @@
+spotinst_token   = "0000000000000000000000000000000000000000000000000000000000000000"
+spotinst_account = "act-00000000"
+cluster_name     = "example-cluster-name"
+cluster_version  = "1.24"
+aws_region       = "us-west-2"
+aws_profile      = "default"
+creator_email    = "example@example.com"
+vpc_id           = "vpc-00000000000000000"
+private_subnets  = ["subnet-00000000000000000", "subnet-00000000000000000", "subnet-00000000000000000"]
+public_subnets   = ["subnet-00000000000000000", "subnet-00000000000000000", "subnet-00000000000000000"]
+creator_email    = "example@example.com"

--- a/examples/from-vpc-eks-blueprint/variables.tf
+++ b/examples/from-vpc-eks-blueprint/variables.tf
@@ -1,0 +1,49 @@
+variable "spotinst_token" {
+  description = "Spot token"
+  type        = string
+}
+
+variable "spotinst_account" {
+  description = "Spot account id"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "EKS cluster and Ocean cluster name"
+  type        = string
+}
+
+variable "cluster_version" {
+  description = "Kubernetes version"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "aws_profile" {
+  description = "AWS profile"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "AWS VPC ID"
+  type        = string
+}
+
+variable "private_subnets" {
+  description = "AWS private subnet IDs"
+  type        = list
+}
+
+variable "public_subnets" {
+  description = "AWS public subnet IDs"
+  type        = list
+}
+
+variable "creator_email" {
+  description = "Creator's email"
+  type        = string
+}

--- a/examples/from-vpc-eks-blueprint/variables.tf
+++ b/examples/from-vpc-eks-blueprint/variables.tf
@@ -35,12 +35,12 @@ variable "vpc_id" {
 
 variable "private_subnets" {
   description = "AWS private subnet IDs"
-  type        = list
+  type        = list(any)
 }
 
 variable "public_subnets" {
   description = "AWS public subnet IDs"
-  type        = list
+  type        = list(any)
 }
 
 variable "creator_email" {


### PR DESCRIPTION
Add support for [EKS Blueprints](https://aws-ia.github.io/terraform-aws-eks-blueprints/v4.21.0/) in our examples for Ocean Spark on AWS. EKS Blueprints are a much easier way to deploy EKS clusters via Terraform in AWS.