### PR TITLE
[examples] add version to spotinst modules and option to enable shutd…

### DIFF
--- a/examples/from-private-vpc/main.tf
+++ b/examples/from-private-vpc/main.tf
@@ -117,7 +117,8 @@ provider "spotinst" {
 }
 
 module "ocean-aws-k8s" {
-  source = "spotinst/ocean-aws-k8s/spotinst"
+  source  = "spotinst/ocean-aws-k8s/spotinst"
+  version = "0.2.3"
 
   cluster_name                = module.eks.cluster_id
   region                      = var.aws_region
@@ -126,6 +127,11 @@ module "ocean-aws-k8s" {
   security_groups             = [module.eks.node_security_group_id]
 
   max_scale_down_percentage = 100
+
+  shutdown_hours = {
+    time_windows = var.shutdown_time_windows,
+    is_enabled   = var.enable_shutdown_hours
+  }
 }
 
 provider "kubernetes" {
@@ -135,7 +141,8 @@ provider "kubernetes" {
 }
 
 module "ocean-controller" {
-  source = "spotinst/ocean-controller/spotinst"
+  source  = "spotinst/ocean-controller/spotinst"
+  version = "0.41.0"
 
   spotinst_token   = var.spotinst_token
   spotinst_account = var.spotinst_account

--- a/examples/from-private-vpc/variables.tf
+++ b/examples/from-private-vpc/variables.tf
@@ -29,3 +29,19 @@ variable "public_subnet_ids" {
 variable "private_subnet_ids" {
   type = list(string)
 }
+
+variable "shutdown_time_windows" {
+  type = list(string)
+  default = [              # GMT
+    "Fri:23:30-Mon:07:30", # Weekends
+    "Mon:23:30-Tue:07:30", # Weekday evenings
+    "Tue:23:30-Wed:07:30",
+    "Wed:23:30-Thu:07:30",
+    "Thu:23:30-Fri:07:30",
+  ]
+}
+
+variable "enable_shutdown_hours" {
+  type    = bool
+  default = false
+}

--- a/examples/from-scratch-eks-blueprint/main.tf
+++ b/examples/from-scratch-eks-blueprint/main.tf
@@ -174,7 +174,8 @@ resource "null_resource" "patience" {
 }
 
 module "ocean-aws-k8s" {
-  source = "spotinst/ocean-aws-k8s/spotinst"
+  source  = "spotinst/ocean-aws-k8s/spotinst"
+  version = "0.2.3"
 
   # Configuration
   cluster_name                = var.cluster_name
@@ -187,14 +188,8 @@ module "ocean-aws-k8s" {
   tags = local.tags
 
   shutdown_hours = {
-    is_enabled = true
-    time_windows = [         # Must be in GMT
-      "Fri:23:30-Mon:13:30", # Weekends
-      "Mon:23:30-Tue:13:30", # Weekday evenings
-      "Tue:23:30-Wed:13:30",
-      "Wed:23:30-Thu:13:30",
-      "Thu:23:30-Fri:13:30",
-    ]
+    time_windows = var.shutdown_time_windows,
+    is_enabled   = var.enable_shutdown_hours
   }
 
   depends_on = [
@@ -212,7 +207,8 @@ provider "spotinst" {
 }
 
 module "ocean-controller" {
-  source = "spotinst/ocean-controller/spotinst"
+  source  = "spotinst/ocean-controller/spotinst"
+  version = "0.41.0"
 
   # Credentials.
   spotinst_token   = var.spotinst_token

--- a/examples/from-scratch-eks-blueprint/variables.tf
+++ b/examples/from-scratch-eks-blueprint/variables.tf
@@ -47,3 +47,19 @@ variable "creator_email" {
   description = "Creator's email"
   type        = string
 }
+
+variable "shutdown_time_windows" {
+  type = list(string)
+  default = [              # GMT
+    "Fri:23:30-Mon:07:30", # Weekends
+    "Mon:23:30-Tue:07:30", # Weekday evenings
+    "Tue:23:30-Wed:07:30",
+    "Wed:23:30-Thu:07:30",
+    "Thu:23:30-Fri:07:30",
+  ]
+}
+
+variable "enable_shutdown_hours" {
+  type    = bool
+  default = false
+}

--- a/examples/from-scratch-with-private-link/main.tf
+++ b/examples/from-scratch-with-private-link/main.tf
@@ -263,7 +263,8 @@ provider "spotinst" {
 }
 
 module "ocean-aws-k8s" {
-  source = "spotinst/ocean-aws-k8s/spotinst"
+  source  = "spotinst/ocean-aws-k8s/spotinst"
+  version = "0.2.3"
 
   cluster_name                = module.eks.cluster_id
   region                      = var.aws_region
@@ -273,6 +274,10 @@ module "ocean-aws-k8s" {
 
   max_scale_down_percentage = 100
 
+  shutdown_hours = {
+    time_windows = var.shutdown_time_windows,
+    is_enabled   = var.enable_shutdown_hours
+  }
 }
 
 provider "kubernetes" {
@@ -282,7 +287,8 @@ provider "kubernetes" {
 }
 
 module "ocean-controller" {
-  source = "spotinst/ocean-controller/spotinst"
+  source  = "spotinst/ocean-controller/spotinst"
+  version = "0.41.0"
 
   spotinst_token   = var.spotinst_token
   spotinst_account = var.spotinst_account

--- a/examples/from-scratch-with-private-link/variable.tf
+++ b/examples/from-scratch-with-private-link/variable.tf
@@ -33,3 +33,19 @@ variable "target_group" {
     "Port"     = "443"
   }
 }
+
+variable "shutdown_time_windows" {
+  type = list(string)
+  default = [              # GMT
+    "Fri:23:30-Mon:07:30", # Weekends
+    "Mon:23:30-Tue:07:30", # Weekday evenings
+    "Tue:23:30-Wed:07:30",
+    "Wed:23:30-Thu:07:30",
+    "Thu:23:30-Fri:07:30"
+  ]
+}
+
+variable "enable_shutdown_hours" {
+  type    = bool
+  default = false
+}

--- a/examples/from-scratch/main.tf
+++ b/examples/from-scratch/main.tf
@@ -161,7 +161,8 @@ provider "spotinst" {
 }
 
 module "ocean-aws-k8s" {
-  source = "spotinst/ocean-aws-k8s/spotinst"
+  source  = "spotinst/ocean-aws-k8s/spotinst"
+  version = "0.2.3"
 
   cluster_name                = module.eks.cluster_id
   region                      = var.aws_region
@@ -171,6 +172,10 @@ module "ocean-aws-k8s" {
 
   max_scale_down_percentage = 100
 
+  shutdown_hours = {
+    time_windows = var.shutdown_time_windows,
+    is_enabled   = var.enable_shutdown_hours
+  }
 }
 
 provider "kubernetes" {
@@ -180,7 +185,8 @@ provider "kubernetes" {
 }
 
 module "ocean-controller" {
-  source = "spotinst/ocean-controller/spotinst"
+  source  = "spotinst/ocean-controller/spotinst"
+  version = "0.41.0"
 
   spotinst_token   = var.spotinst_token
   spotinst_account = var.spotinst_account

--- a/examples/from-scratch/variables.tf
+++ b/examples/from-scratch/variables.tf
@@ -25,3 +25,19 @@ variable "vpc_name" {
 variable "vpc_cidr" {
   type = string
 }
+
+variable "shutdown_time_windows" {
+  type = list(string)
+  default = [              # GMT
+    "Fri:23:30-Mon:07:30", # Weekends
+    "Mon:23:30-Tue:07:30", # Weekday evenings
+    "Tue:23:30-Wed:07:30",
+    "Wed:23:30-Thu:07:30",
+    "Thu:23:30-Fri:07:30",
+  ]
+}
+
+variable "enable_shutdown_hours" {
+  type    = bool
+  default = false
+}

--- a/examples/from-vpc-eks-blueprint/main.tf
+++ b/examples/from-vpc-eks-blueprint/main.tf
@@ -133,7 +133,8 @@ resource "null_resource" "patience" {
 }
 
 module "ocean-aws-k8s" {
-  source = "spotinst/ocean-aws-k8s/spotinst"
+  source  = "spotinst/ocean-aws-k8s/spotinst"
+  version = "0.2.3"
 
   # Configuration
   cluster_name                = var.cluster_name
@@ -146,14 +147,8 @@ module "ocean-aws-k8s" {
   tags = local.tags
 
   shutdown_hours = {
-    is_enabled = true
-    time_windows = [         # Must be in GMT
-      "Fri:23:30-Mon:13:30", # Weekends
-      "Mon:23:30-Tue:13:30", # Weekday evenings
-      "Tue:23:30-Wed:13:30",
-      "Wed:23:30-Thu:13:30",
-      "Thu:23:30-Fri:13:30",
-    ]
+    time_windows = var.shutdown_time_windows,
+    is_enabled   = var.enable_shutdown_hours
   }
 
   depends_on = [
@@ -171,7 +166,8 @@ provider "spotinst" {
 }
 
 module "ocean-controller" {
-  source = "spotinst/ocean-controller/spotinst"
+  source  = "spotinst/ocean-controller/spotinst"
+  version = "0.41.0"
 
   # Credentials.
   spotinst_token   = var.spotinst_token

--- a/examples/from-vpc-eks-blueprint/variables.tf
+++ b/examples/from-vpc-eks-blueprint/variables.tf
@@ -47,3 +47,19 @@ variable "creator_email" {
   description = "Creator's email"
   type        = string
 }
+
+variable "shutdown_time_windows" {
+  type = list(string)
+  default = [
+    "Fri:23:30-Mon:13:30", # Weekends
+    "Mon:23:30-Tue:13:30", # Weekday evenings
+    "Tue:23:30-Wed:13:30",
+    "Wed:23:30-Thu:13:30",
+    "Thu:23:30-Fri:13:30",
+  ]
+}
+
+variable "enable_shutdown_hours" {
+  type    = bool
+  default = false
+}

--- a/examples/gcp-from-scratch/main.tf
+++ b/examples/gcp-from-scratch/main.tf
@@ -87,6 +87,13 @@ resource "spotinst_ocean_gke_import" "ocean" {
   cluster_name          = google_container_cluster.cluster.name
   controller_cluster_id = var.cluster_name
   location              = var.region
+
+  scheduled_task {
+    shutdown_hours {
+      is_enabled   = var.enable_shutdown_hours
+      time_windows = var.shutdown_time_windows
+    }
+  }
 }
 
 data "google_client_config" "default" {}

--- a/examples/gcp-from-scratch/variables.tf
+++ b/examples/gcp-from-scratch/variables.tf
@@ -17,3 +17,19 @@ variable "cluster_name" {
 variable "region" {
   type = string
 }
+
+variable "shutdown_time_windows" {
+  type = list(string)
+  default = [              # GMT
+    "Fri:23:30-Mon:07:30", # Weekends
+    "Mon:23:30-Tue:07:30", # Weekday evenings
+    "Tue:23:30-Wed:07:30",
+    "Wed:23:30-Thu:07:30",
+    "Thu:23:30-Fri:07:30",
+  ]
+}
+
+variable "enable_shutdown_hours" {
+  type    = bool
+  default = false
+}

--- a/examples/gcp-from-vpc/main.tf
+++ b/examples/gcp-from-vpc/main.tf
@@ -45,6 +45,13 @@ resource "spotinst_ocean_gke_import" "ocean" {
   cluster_name          = var.cluster_name
   controller_cluster_id = var.cluster_name
   location              = var.region
+
+  scheduled_task {
+    shutdown_hours {
+      is_enabled   = var.enable_shutdown_hours
+      time_windows = var.shutdown_time_windows
+    }
+  }
 }
 
 data "google_client_config" "default" {}

--- a/examples/gcp-from-vpc/variables.tf
+++ b/examples/gcp-from-vpc/variables.tf
@@ -40,3 +40,19 @@ variable "services_ipv4_cidr_block" {
   type    = string
   default = "172.20.0.0/16"
 }
+
+variable "shutdown_time_windows" {
+  type = list(string)
+  default = [              # GMT
+    "Fri:23:30-Mon:07:30", # Weekends
+    "Mon:23:30-Tue:07:30", # Weekday evenings
+    "Tue:23:30-Wed:07:30",
+    "Wed:23:30-Thu:07:30",
+    "Thu:23:30-Fri:07:30",
+  ]
+}
+
+variable "enable_shutdown_hours" {
+  type    = bool
+  default = false
+}

--- a/examples/gcp-import-gke-cluster/main.tf
+++ b/examples/gcp-import-gke-cluster/main.tf
@@ -23,6 +23,13 @@ resource "spotinst_ocean_gke_import" "ocean" {
   cluster_name          = var.cluster_name
   controller_cluster_id = var.cluster_name
   location              = var.location
+
+  scheduled_task {
+    shutdown_hours {
+      is_enabled   = var.enable_shutdown_hours
+      time_windows = var.shutdown_time_windows
+    }
+  }
 }
 
 provider "kubernetes" {

--- a/examples/gcp-import-gke-cluster/variables.tf
+++ b/examples/gcp-import-gke-cluster/variables.tf
@@ -17,3 +17,19 @@ variable "cluster_name" {
 variable "location" {
   type = string
 }
+
+variable "shutdown_time_windows" {
+  type = list(string)
+  default = [              # GMT
+    "Fri:23:30-Mon:07:30", # Weekends
+    "Mon:23:30-Tue:07:30", # Weekday evenings
+    "Tue:23:30-Wed:07:30",
+    "Wed:23:30-Thu:07:30",
+    "Thu:23:30-Fri:07:30",
+  ]
+}
+
+variable "enable_shutdown_hours" {
+  type    = bool
+  default = false
+}

--- a/examples/import-eks-cluster/main.tf
+++ b/examples/import-eks-cluster/main.tf
@@ -21,7 +21,8 @@ provider "spotinst" {
 }
 
 module "ocean-aws-k8s" {
-  source = "spotinst/ocean-aws-k8s/spotinst"
+  source  = "spotinst/ocean-aws-k8s/spotinst"
+  version = "0.2.3"
 
   cluster_name                = var.cluster_name
   region                      = var.aws_region
@@ -30,6 +31,11 @@ module "ocean-aws-k8s" {
   security_groups             = [var.node_security_group_id]
 
   max_scale_down_percentage = 100
+
+  shutdown_hours = {
+    time_windows = var.shutdown_time_windows,
+    is_enabled   = var.enable_shutdown_hours
+  }
 
 }
 
@@ -40,7 +46,8 @@ provider "kubernetes" {
 }
 
 module "ocean-controller" {
-  source = "spotinst/ocean-controller/spotinst"
+  source  = "spotinst/ocean-controller/spotinst"
+  version = "0.41.0"
 
   spotinst_token   = var.spotinst_token
   spotinst_account = var.spotinst_account

--- a/examples/import-eks-cluster/variables.tf
+++ b/examples/import-eks-cluster/variables.tf
@@ -29,3 +29,21 @@ variable "node_iam_instance_profile_arn" {
 variable "node_security_group_id" {
   type = string
 }
+
+variable "shutdown_time_windows" {
+  type = list(string)
+  default = [              # GMT
+    "Fri:23:30-Mon:07:30", # Weekends
+    "Mon:23:30-Tue:07:30", # Weekday evenings
+    "Tue:23:30-Wed:07:30",
+    "Wed:23:30-Thu:07:30",
+    "Thu:23:30-Fri:07:30",
+  ]
+}
+
+variable "enable_shutdown_hours" {
+  type    = bool
+  default = false
+}
+
+


### PR DESCRIPTION
- Added option to enable shutdown hours in ocean spark cluster to avoid unnecessary costs when possible.
## JIRA 
- [BGD-2958](https://spotinst.atlassian.net/browse/BGD-2958) 

[BGD-2958]: https://spotinst.atlassian.net/browse/BGD-2958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ