### PR TITLE
Bgd 3435 terraform should use restricted rbac

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Terraform module to install the [Ocean for Apache Spark](https://spot.io/products/ocean-apache-spark/) data platform.
 
-## Introduction
+## *Introduction*
 
 This module imports an existing Ocean cluster into Ocean Spark.
 
@@ -10,7 +10,7 @@ This module imports an existing Ocean cluster into Ocean Spark.
 * Existing EKS/GKE/AKS Cluster
 * EKS/GKE/AKS cluster integrated with Spot Ocean
 
-### Usage
+## *Usage*
 ```hcl
 provider "spotinst" {
   token   = var.spotinst_token
@@ -18,13 +18,20 @@ provider "spotinst" {
 }
 
 module "ocean-spark" {
-  "spotinst/ocean-spark/spotinst"
+  source = "spotinst/ocean-spark/spotinst"
 
   ocean_cluster_id = var.ocean_cluster_id
 }
 ```
 
-### Examples
+##  *Upgrade guides*
+- [Upgrade to v3.x.](/docs/UPGRADE-v3.md)
+- [Upgrade to v2.x.](/docs/UPGRADE-v2.md)
+- [Upgrade to v1.x](/docs/UPGRADE-v1.md)
+
+
+## *Examples*
+
 It can be combined with other Terraform modules to support a number of installation methods for Ocean Spark:
 1. Create an Ocean Spark cluster from scratch in your AWS account
 2. Create an Ocean Spark Cluster from scratch in your AWS account with AWS Private Link support.
@@ -121,43 +128,6 @@ Folder [`examples/import-ocean-cluster/`](https://github.com/spotinst/terraform-
 
 3- Once the script is completed with success, you can now run `terraform destroy`
 
-## Migration Guide
-
-### v2 migration guide
-
-#### By default the Ocean Spark deployer jobs now run in the kube-system namespace.
-
-To avoid issues for existing clusters you will need to set the following line:
-```diff
-module "ocean-spark" {
-  "spotinst/ocean-spark/spotinst"
-
-  ocean_cluster_id   = var.ocean_cluster_id
-+ deployer_namespace = "spot-system"
-}
-```
-
-#### Deprecated `ofas_managed_load_balancer` variable has been deleted
-
-Use `ingress_managed_load_balancer` instead
-
-###  v1 migration guide
-
-This migration revolves around 1 topic:
-
-- The use of the `spotinst_ocean_spark` resource to manage the cluster state instead of relying on a `kubernetes job` on the 1st apply
-
-#### Steps
-
-1- Upgrade `spotinst provider` to `>= 1.89`
-
-2- [Retrieve from the UI](https://console.spotinst.com/ocean/spark/clusters) your Ocean Spark `Cluster ID`
-
-3- Import the resource into your `terraform state`
-```
-terraform import module.ocean-spark.spotinst_ocean_spark.example osc-abcd1234
-```
-
 
 ## Terraform module documentation
 
@@ -175,7 +145,7 @@ terraform import module.ocean-spark.spotinst_ocean_spark.example osc-abcd1234
 
 | Name | Version |
 |------|---------|
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
 | <a name="provider_spotinst"></a> [spotinst](#provider\_spotinst) | >= 1.115.0, < 1.123.0 |
 | <a name="provider_validation"></a> [validation](#provider\_validation) | 1.0.0 |
 
@@ -187,9 +157,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [kubernetes_cluster_role_binding.deployer](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding) | resource |
-| [kubernetes_namespace.spot-system](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
-| [kubernetes_service_account.deployer](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
+| [null_resource.apply_kubernetes_manifest](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [spotinst_ocean_spark.cluster](https://registry.terraform.io/providers/spotinst/spotinst/latest/docs/resources/ocean_spark) | resource |
 | [spotinst_ocean_spark_virtual_node_group.this](https://registry.terraform.io/providers/spotinst/spotinst/latest/docs/resources/ocean_spark_virtual_node_group) | resource |
 | [validation_warning.log_collection_collect_driver_logs](https://registry.terraform.io/providers/tlkamp/validation/1.0.0/docs/data-sources/warning) | data source |
@@ -199,6 +167,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_attach_dedicated_virtual_node_groups"></a> [attach\_dedicated\_virtual\_node\_groups](#input\_attach\_dedicated\_virtual\_node\_groups) | List of virtual node group IDs to attach to the cluster | `list(string)` | `[]` | no |
+| <a name="input_cluster_config"></a> [cluster\_config](#input\_cluster\_config) | Configuration for Ocean Kubernetes cluster | <pre>object({<br>    cluster_name               = string<br>    certificate_authority_data = string<br>    server_endpoint            = string<br>    token                      = optional(string)<br>    client_certificate         = optional(string)<br>    client_key                 = optional(string)<br>  })</pre> | n/a | yes |
 | <a name="input_compute_create_vngs"></a> [compute\_create\_vngs](#input\_compute\_create\_vngs) | Controls whether dedicated Ocean Spark VNGs will be created by the cluster creation process | `bool` | `true` | no |
 | <a name="input_compute_use_taints"></a> [compute\_use\_taints](#input\_compute\_use\_taints) | Controls whether the Ocean Spark cluster will use taints to schedule workloads | `bool` | `true` | no |
 | <a name="input_create_cluster"></a> [create\_cluster](#input\_create\_cluster) | Controls whether the Ocean for Apache Spark cluster should be created (it affects all resources) | `bool` | `true` | no |

--- a/docs/UPGRADE-v1.md
+++ b/docs/UPGRADE-v1.md
@@ -1,0 +1,17 @@
+###  v1 upgrade guide
+
+*This upgrade revolves around one topic:*
+
+The use of the `spotinst_ocean_spark` resource to manage the cluster state instead of relying on a `kubernetes job` on the first apply.
+
+To upgrade to v1 please follow the steps bellow:
+
+1- Upgrade `spotinst provider` to `>= 1.89`
+
+2- [Retrieve from the UI](https://console.spotinst.com/ocean/spark/clusters) your Ocean Spark `Cluster ID`
+
+3- Import the resource into your `terraform state`:
+
+```
+terraform import module.ocean-spark.spotinst_ocean_spark.example osc-abcd1234
+```

--- a/docs/UPGRADE-v2.md
+++ b/docs/UPGRADE-v2.md
@@ -1,0 +1,19 @@
+## Upgrade to v2.x.x from v1.x.x
+
+By default the Ocean Spark deployer jobs now run in the kube-system namespace.
+
+To avoid issues for existing clusters you will need to set the following line:
+
+```diff
+module "ocean-spark" {
+  "spotinst/ocean-spark/spotinst"
+
+  ocean_cluster_id   = var.ocean_cluster_id
++ deployer_namespace = "spot-system"
+}
+```
+
+
+#### Deprecated :
+
+- `ofas_managed_load_balancer` variable has been deleted. Use `ingress_managed_load_balancer` instead

--- a/docs/UPGRADE-v3.md
+++ b/docs/UPGRADE-v3.md
@@ -1,0 +1,72 @@
+## Upgrade to v3.x.x from v2.x.x
+
+To migrate from *v2.xx* to *v3.x.x*, please follow the steps bellow:
+
+1- If you specified the spot-system namespace for the deployer job to run, then you will need to remove it from the terraform state:
+
+`terraform state rm module.ocean-spark.kubernetes_namespace.spot-system`
+
+2- Remove the deployer RBAC service-account and role-binding from the terraform state as well:
+
+- `terraform state rm module.ocean-spark.kubernetes_service_account.deployer`
+
+- `terraform state rm module.ocean-spark.kubernetes_cluster_role_binding.deployer`
+
+3- Add the new required `cluster_config` variable depending on your cloud provider
+
+- for *AWS*:
+
+    ```diff
+    module "ocean-spark" {
+    source = "spotinst/ocean-spark/spotinst"
+    version = "3.0.0"
+
+    ocean_cluster_id = var.ocean_cluster_id
+
+    + cluster_config = {
+    +     cluster_name               = var.cluster_name
+    +    certificate_authority_data = data.aws_eks_cluster.this.certificate_authority[0].data
+    +    server_endpoint            = data.aws_eks_cluster.this.endpoint
+    +    token                      = data.aws_eks_cluster_auth.this.token
+    + }
+    }
+    ```
+
+- for *GCP*:
+
+    ```diff
+    module "ocean-spark" {
+    source = "spotinst/ocean-spark/spotinst"
+    version = "3.0.0"
+
+    ocean_cluster_id = var.ocean_cluster_id
+
+    + cluster_config = {
+    +    cluster_name               = google_container_cluster.cluster.name
+    +    certificate_authority_data = google_container_cluster.cluster.master_auth[0].cluster_ca_certificate
+    +    server_endpoint            = "https://${google_container_cluster.cluster.endpoint}"
+    +    token                      = data.google_client_config.default.access_token
+    + }
+    }
+    ```
+
+- for *Azure*:
+
+    ```diff
+    module "ocean-spark" {
+    source = "spotinst/ocean-spark/spotinst"
+    version = "3.0.0"
+
+    ocean_cluster_id = var.ocean_cluster_id
+
+    + cluster_config = {
+    +    cluster_name               = var.cluster_name
+    +    certificate_authority_data = module.aks.admin_cluster_ca_certificate
+    +    server_endpoint            = module.aks.admin_host
+    +    client_certificate         = module.aks.admin_client_certificate
+    +    client_key                 = module.aks.admin_client_key
+    + }
+    }
+    ```
+
+4- Run `terraform init`  then `terraform apply` and that's it.

--- a/examples/azure-from-scratch/variables.tf
+++ b/examples/azure-from-scratch/variables.tf
@@ -1,12 +1,16 @@
 variable "azure_client_id" {
-  type = string
+  type      = string
+  sensitive = true
 }
 variable "azure_client_secret" {
-  type = string
+  type      = string
+  sensitive = true
 }
 variable "azure_tenant_id" {
-  type = string
+  type      = string
+  sensitive = true
 }
+
 variable "azure_subscription_id" {
   type = string
 }

--- a/examples/azure-from-vpc/main.tf
+++ b/examples/azure-from-vpc/main.tf
@@ -114,6 +114,14 @@ module "ocean-spark" {
 
   ocean_cluster_id = module.ocean-aks-np.ocean_id
 
+  cluster_config = {
+    cluster_name               = var.cluster_name
+    certificate_authority_data = module.aks.admin_cluster_ca_certificate
+    server_endpoint            = module.aks.admin_host
+    client_certificate         = module.aks.admin_client_certificate
+    client_key                 = module.aks.admin_client_key
+  }
+
   depends_on = [
     module.ocean-aks-np,
     module.ocean-controller,

--- a/examples/azure-import-aks-cluster/main.tf
+++ b/examples/azure-import-aks-cluster/main.tf
@@ -95,6 +95,14 @@ module "ocean-spark" {
 
   ocean_cluster_id = module.ocean-aks-np.ocean_id
 
+  cluster_config = {
+    cluster_name               = var.cluster_name
+    certificate_authority_data = local.aks_admin.cluster_ca_certificate
+    server_endpoint            = local.aks_admin.host
+    client_certificate         = local.aks_admin.client_certificate
+    client_key                 = local.aks_admin.client_key
+  }
+
   depends_on = [
     module.ocean-aks-np,
     module.ocean-controller,

--- a/examples/from-private-vpc/main.tf
+++ b/examples/from-private-vpc/main.tf
@@ -159,6 +159,13 @@ module "ocean-spark" {
 
   ocean_cluster_id = module.ocean-aws-k8s.ocean_id
 
+  cluster_config = {
+    cluster_name               = module.eks.cluster_id
+    certificate_authority_data = module.eks.cluster_certificate_authority_data
+    server_endpoint            = module.eks.cluster_endpoint
+    token                      = data.aws_eks_cluster_auth.this.token
+  }
+
   depends_on = [
     module.ocean-aws-k8s,
     module.ocean-controller,

--- a/examples/from-scratch-eks-blueprint/main.tf
+++ b/examples/from-scratch-eks-blueprint/main.tf
@@ -227,6 +227,13 @@ module "ocean-spark" {
 
   ocean_cluster_id = module.ocean-aws-k8s.ocean_id
 
+  cluster_config = {
+    cluster_name               = var.cluster_name
+    certificate_authority_data = module.eks_blueprints.eks_cluster_certificate_authority_data
+    server_endpoint            = module.eks_blueprints.eks_cluster_endpoint
+    token                      = data.aws_eks_cluster_auth.this.token
+  }
+
   depends_on = [
     module.ocean-aws-k8s,
     module.ocean-controller,

--- a/examples/from-scratch-with-private-link/main.tf
+++ b/examples/from-scratch-with-private-link/main.tf
@@ -312,6 +312,13 @@ module "ocean-spark" {
   enable_private_link                           = true
   ingress_private_link_endpoint_service_address = aws_vpc_endpoint_service.this.service_name
 
+  cluster_config = {
+    cluster_name               = module.eks.cluster_id
+    certificate_authority_data = module.eks.cluster_certificate_authority_data
+    server_endpoint            = module.eks.cluster_endpoint
+    token                      = data.aws_eks_cluster_auth.this.token
+  }
+
   depends_on = [
     module.ocean-aws-k8s,
     module.ocean-controller,

--- a/examples/from-scratch/main.tf
+++ b/examples/from-scratch/main.tf
@@ -197,7 +197,6 @@ module "ocean-controller" {
 ################################################################################
 # Import Ocean cluster into Ocean Spark
 ################################################################################
-
 module "ocean-spark" {
   source = "../.."
 
@@ -207,4 +206,11 @@ module "ocean-spark" {
     module.ocean-aws-k8s,
     module.ocean-controller,
   ]
+
+  cluster_config = {
+    cluster_name               = module.eks.cluster_id
+    certificate_authority_data = module.eks.cluster_certificate_authority_data
+    server_endpoint            = module.eks.cluster_endpoint
+    token                      = data.aws_eks_cluster_auth.this.token
+  }
 }

--- a/examples/from-vpc-eks-blueprint/main.tf
+++ b/examples/from-vpc-eks-blueprint/main.tf
@@ -186,6 +186,13 @@ module "ocean-spark" {
 
   ocean_cluster_id = module.ocean-aws-k8s.ocean_id
 
+  cluster_config = {
+    cluster_name               = module.eks.cluster_id
+    certificate_authority_data = module.eks_blueprints.eks_cluster_certificate_authority_data
+    server_endpoint            = module.eks_blueprints.eks_cluster_endpoint
+    token                      = data.aws_eks_cluster_auth.this.token
+  }
+
   depends_on = [
     module.ocean-aws-k8s,
     module.ocean-controller,

--- a/examples/gcp-from-scratch/main.tf
+++ b/examples/gcp-from-scratch/main.tf
@@ -128,4 +128,11 @@ module "ocean-spark" {
     spotinst_ocean_gke_import.ocean,
     module.ocean-controller,
   ]
+
+  cluster_config = {
+    cluster_name               = google_container_cluster.cluster.name
+    certificate_authority_data = google_container_cluster.cluster.master_auth[0].cluster_ca_certificate
+    server_endpoint            = "https://${google_container_cluster.cluster.endpoint}"
+    token                      = data.google_client_config.default.access_token
+  }
 }

--- a/examples/gcp-from-vpc/main.tf
+++ b/examples/gcp-from-vpc/main.tf
@@ -82,6 +82,13 @@ module "ocean-spark" {
 
   ocean_cluster_id = spotinst_ocean_gke_import.ocean.id
 
+  cluster_config = {
+    cluster_name               = google_container_cluster.cluster.name
+    certificate_authority_data = google_container_cluster.cluster.master_auth[0].cluster_ca_certificate
+    server_endpoint            = "https://${google_container_cluster.cluster.endpoint}"
+    token                      = data.google_client_config.default.access_token
+  }
+
   depends_on = [
     spotinst_ocean_gke_import.ocean,
     module.ocean-controller,

--- a/examples/gcp-import-gke-cluster/main.tf
+++ b/examples/gcp-import-gke-cluster/main.tf
@@ -64,4 +64,11 @@ module "ocean-spark" {
     spotinst_ocean_gke_import.ocean,
     module.ocean-controller,
   ]
+
+  cluster_config = {
+    cluster_name               = data.google_container_cluster.gke.name
+    certificate_authority_data = data.google_container_cluster.gke.master_auth[0].cluster_ca_certificate
+    server_endpoint            = "https://${data.google_container_cluster.gke.endpoint}"
+    token                      = data.google_client_config.default.access_token
+  }
 }

--- a/examples/import-eks-cluster/main.tf
+++ b/examples/import-eks-cluster/main.tf
@@ -64,6 +64,13 @@ module "ocean-spark" {
 
   ocean_cluster_id = module.ocean-aws-k8s.ocean_id
 
+  cluster_config = {
+    cluster_name               = var.cluster_name
+    certificate_authority_data = data.aws_eks_cluster.this.certificate_authority[0].data
+    server_endpoint            = data.aws_eks_cluster.this.endpoint
+    token                      = data.aws_eks_cluster_auth.this.token
+  }
+
   depends_on = [
     module.ocean-aws-k8s,
     module.ocean-controller,

--- a/examples/import-ocean-cluster/main.tf
+++ b/examples/import-ocean-cluster/main.tf
@@ -2,13 +2,32 @@ provider "kubernetes" {
   config_path = "~/.kube/config"
 }
 
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+}
+
 provider "spotinst" {
   token   = var.spotinst_token
   account = var.spotinst_account
+}
+
+data "aws_eks_cluster_auth" "this" {
+  name = var.cluster_name
+}
+data "aws_eks_cluster" "this" {
+  name = var.cluster_name
 }
 
 module "ocean-spark" {
   source = "../.."
 
   ocean_cluster_id = var.ocean_cluster_id
+
+  cluster_config = {
+    cluster_name               = var.cluster_name
+    certificate_authority_data = data.aws_eks_cluster.this.certificate_authority[0].data
+    server_endpoint            = data.aws_eks_cluster.this.endpoint
+    token                      = data.aws_eks_cluster_auth.this.token
+  }
 }

--- a/examples/import-ocean-cluster/variables.tf
+++ b/examples/import-ocean-cluster/variables.tf
@@ -9,3 +9,15 @@ variable "spotinst_account" {
 variable "ocean_cluster_id" {
   type = string
 }
+
+variable "cluster_name" {
+  type = string
+}
+
+variable "aws_region" {
+  type = string
+}
+
+variable "aws_profile" {
+  type = string
+}

--- a/examples/import-ocean-cluster/versions.tf
+++ b/examples/import-ocean-cluster/versions.tf
@@ -8,5 +8,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.10"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.75"
+    }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -125,3 +125,24 @@ variable "deployer_namespace" {
     error_message = "Error: deployer_namespace should either be spot-system or kube-system."
   }
 }
+
+variable "cluster_config" {
+  description = "Configuration for Ocean Kubernetes cluster"
+  type = object({
+    cluster_name               = string
+    certificate_authority_data = string
+    server_endpoint            = string
+    token                      = optional(string)
+    client_certificate         = optional(string)
+    client_key                 = optional(string)
+  })
+  sensitive = true
+
+  validation {
+    condition = (
+      can(var.cluster_config.token) ||
+      (can(var.cluster_config.client_certificate) && can(var.cluster_config.client_key))
+    )
+    error_message = "Either 'token' must be provided, or both 'client_certificate' and 'client_key' must be provided."
+  }
+}


### PR DESCRIPTION
The terraform module should use the new restricted RBAC : 
- The bigdata-deployer service account should not be cluster admin.
- Terraform must not manage the spot-system namespace and the bigdata-deployer service account, otherwise terraform destroy will not work.

# Jira Ticket
- [BGD-3435](https://spotinst.atlassian.net/browse/BGD-3435?atlOrigin=eyJpIjoiYTVkMDBlMTAxNmU4NDM3YmE4OWNhNDAzOGQyZjQ2MjMiLCJwIjoiaiJ9)

# Demo
# Checklist:



[BGD-3435]: https://spotinst.atlassian.net/browse/BGD-3435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ