### PR TITLE
[examples/gcp-*] BGD-3479 set disk type to pd-ssd by default in gcp examples

### DIFF
--- a/examples/gcp-from-scratch/main.tf
+++ b/examples/gcp-from-scratch/main.tf
@@ -88,6 +88,8 @@ resource "spotinst_ocean_gke_import" "ocean" {
   controller_cluster_id = var.cluster_name
   location              = var.region
 
+  root_volume_type = "pd-ssd"
+
   scheduled_task {
     shutdown_hours {
       is_enabled   = var.enable_shutdown_hours

--- a/examples/gcp-from-vpc/main.tf
+++ b/examples/gcp-from-vpc/main.tf
@@ -46,6 +46,8 @@ resource "spotinst_ocean_gke_import" "ocean" {
   controller_cluster_id = var.cluster_name
   location              = var.region
 
+  root_volume_type = "pd-ssd"
+
   scheduled_task {
     shutdown_hours {
       is_enabled   = var.enable_shutdown_hours

--- a/examples/gcp-import-gke-cluster/main.tf
+++ b/examples/gcp-import-gke-cluster/main.tf
@@ -24,6 +24,8 @@ resource "spotinst_ocean_gke_import" "ocean" {
   controller_cluster_id = var.cluster_name
   location              = var.location
 
+  root_volume_type = "pd-ssd"
+
   scheduled_task {
     shutdown_hours {
       is_enabled   = var.enable_shutdown_hours


### PR DESCRIPTION
we should make sure the Ocean clusters have rootVolumeType: pd-ssd (when imported from GKE cluster created by our terraform module)

# Jira Ticket

- [BGD-3479](https://spotinst.atlassian.net/browse/BGD-3479?atlOrigin=eyJpIjoiNTU0ZTc5MTQ4NWQ2NDkwYmFlMDM2YzViMjI4ODMzZDUiLCJwIjoiaiJ9)

# Demo

# Checklist

[BGD-3479]: https://spotinst.atlassian.net/browse/BGD-3479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ